### PR TITLE
loop処理を追加

### DIFF
--- a/Mario_Copy/src/Origin/Object/Enemy/enemy_move.cpp
+++ b/Mario_Copy/src/Origin/Object/Enemy/enemy_move.cpp
@@ -1,5 +1,6 @@
 
 #include "enemy_move.h"
+#include "enemy.h"
 
 
 cEnemyMove::cEnemyMove(cEnemy* obj) :
@@ -9,11 +10,19 @@ m_pos_x(0) {
 
 
 void cEnemyMove::update() {
-  // if (m_enemy->isFaint()) return;
+  if (m_enemy->isFaint()) return;
 
-  m_pos_x += SPEED;
+  m_pos_x += m_move_stat.speed;
+  loop();
 }
 
+void cEnemyMove::loop() {
+  if (m_pos_x > edge.right)
+    m_pos_x = edge.left;
+
+  if (m_pos_x < edge.left)
+    m_pos_x = edge.right;
+}
 
 float cEnemyMove::getPosX() {
   return m_pos_x;

--- a/Mario_Copy/src/Origin/Object/Enemy/enemy_move.h
+++ b/Mario_Copy/src/Origin/Object/Enemy/enemy_move.h
@@ -17,11 +17,16 @@ private:
   // ‰æ–Ê’[î•ñ
   common::WindowEdge edge;
 
-
+  void loop();
 
   enum MoveSpeed{
     SPEED = 5
   };
+
+  struct MoveStatus{
+    float speed = MoveSpeed::SPEED;
+    const float sign  = -1;
+  }m_move_stat;
 
   float m_pos_x;
 };


### PR DESCRIPTION
## 追加点
- cEnemyMoveにloop処理を追加

## 概要
- 画面端から出ると反対側の画面端から出現させる処理
- 点で判定を行っているので画像サイズなどは考慮してません